### PR TITLE
Fix backend test step

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,0 +1,3 @@
+export default {
+  testEnvironment: 'node',
+};

--- a/backend/src/services/__tests__/yahooService.test.js
+++ b/backend/src/services/__tests__/yahooService.test.js
@@ -1,0 +1,51 @@
+import { fetchByJan } from '../yahooService.js';
+
+describe('fetchByJan', () => {
+  const realFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = realFetch;
+  });
+
+  test('returns product when hit found', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        totalResultsReturned: 1,
+        hits: [
+          {
+            name: 'Example',
+            brand: { name: 'Brand' },
+            image: { medium: 'img.png' },
+            genreCategory: { name: 'Snacks' },
+          },
+        ],
+      }),
+    });
+    process.env.YAHOO_APP_ID = 'dummy';
+    const result = await fetchByJan('12345678');
+    expect(result).toEqual({
+      name: 'Example',
+      brand: 'Brand',
+      image: 'img.png',
+      meta: expect.any(Object),
+      group: 'snacks',
+    });
+  });
+
+  test('returns null when no results', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ totalResultsReturned: 0 }),
+    });
+    process.env.YAHOO_APP_ID = 'dummy';
+    const result = await fetchByJan('12345678');
+    expect(result).toBeNull();
+  });
+
+  test('throws error when response not ok', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: false });
+    process.env.YAHOO_APP_ID = 'dummy';
+    await expect(fetchByJan('12345678')).rejects.toThrow('Yahoo API');
+  });
+});


### PR DESCRIPTION
## Summary
- test yahoo API service with jest
- remove `--passWithNoTests` so CI fails when tests are missing or failing

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_685aa20bf594832e86a57621caed3866