### PR TITLE
Add shelf selection and stock history

### DIFF
--- a/backend/src/models/stock.js
+++ b/backend/src/models/stock.js
@@ -1,11 +1,12 @@
 /* eslint-env node */
 import { pool } from "../db.js";
 
-export async function listStocks({ q, group, barcode }) {
+export async function listStocks({ q, group, barcode, product }) {
   let where = [];
   let vals = [];
-  if (barcode) {
-    vals.push(barcode);
+  const bc = barcode || product;
+  if (bc) {
+    vals.push(bc);
     where.push(`p.barcode = $${vals.length}`);
   }
   if (group) {
@@ -18,9 +19,10 @@ export async function listStocks({ q, group, barcode }) {
   }
   const clause = where.length ? "WHERE " + where.join(" AND ") : "";
   const sql = `
-    SELECT s.*, p.name, p.image_url
+    SELECT s.*, p.name, p.image_url, sh.label AS shelf_label
       FROM stock s
       JOIN products p ON p.id = s.product_id
+      LEFT JOIN shelves sh ON sh.id = s.shelf_id
       ${clause}
     ORDER BY updated_at DESC LIMIT 100`;
   const { rows } = await pool.query(sql, vals);
@@ -33,16 +35,21 @@ export async function addOrUpdateStock({
   shelf_id,
   delta,
 }) {
-  return pool
-    .query(
-      `INSERT INTO stock (user_id, product_id, shelf_id, quantity)
+  const { rows } = await pool.query(
+    `INSERT INTO stock (user_id, product_id, shelf_id, quantity)
        VALUES ($1,$2,$3,$4)
        ON CONFLICT (user_id, product_id, shelf_id)
        DO UPDATE SET quantity = stock.quantity + $4
        RETURNING *`,
-      [user_id, product_id, shelf_id, delta]
-    )
-    .then((r) => r.rows[0]);
+    [user_id, product_id, shelf_id, delta]
+  );
+  const stock = rows[0];
+  await pool.query(
+    `INSERT INTO stock_history (stock_id, delta, after_qty)
+       VALUES ($1,$2,$3)`,
+    [stock.id, delta, stock.quantity]
+  );
+  return stock;
 }
 
 export async function upsertStockAbsolute({
@@ -51,16 +58,28 @@ export async function upsertStockAbsolute({
   shelf_id,
   quantity,
 }) {
-  return pool
-    .query(
-      `INSERT INTO stock (user_id, product_id, shelf_id, quantity)
+  const prev = await pool.query(
+    `SELECT id, quantity FROM stock WHERE user_id=$1 AND product_id=$2 AND shelf_id IS NOT DISTINCT FROM $3`,
+    [user_id, product_id, shelf_id]
+  );
+  const prevQty = prev.rows[0]?.quantity ?? 0;
+
+  const { rows } = await pool.query(
+    `INSERT INTO stock (user_id, product_id, shelf_id, quantity)
        VALUES ($1,$2,$3,$4)
        ON CONFLICT (user_id, product_id, shelf_id)
        DO UPDATE SET quantity = $4
        RETURNING *`,
-      [user_id, product_id, shelf_id, quantity]
-    )
-    .then((r) => r.rows[0]);
+    [user_id, product_id, shelf_id, quantity]
+  );
+  const stock = rows[0];
+  const delta = quantity - prevQty;
+  await pool.query(
+    `INSERT INTO stock_history (stock_id, delta, after_qty)
+       VALUES ($1,$2,$3)`,
+    [stock.id, delta, stock.quantity]
+  );
+  return stock;
 }
 
 export async function createEmptyStock(productId) {

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -11,6 +11,8 @@ import meRouter from "./routes/me.js";
 const app = express();
 app.use(cors({ origin: true, credentials: true }));
 app.use(express.json());
+// HTML form (application/x-www-form-urlencoded) 対応
+app.use(express.urlencoded({ extended: false }));
 app.use(auth);
 
 app.use("/api/items", items);


### PR DESCRIPTION
## Summary
- add shelf dropdown to stock form
- join shelves in stock listing and support `product` query
- log stock changes into `stock_history`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685b5445f074832e8b180a422961c792