### PR TITLE
feature(stock): add group view

### DIFF
--- a/backend/src/routes/products.js
+++ b/backend/src/routes/products.js
@@ -40,7 +40,7 @@ async function downloadAndUploadImage(product) {
     const imagePath = await uploadImageBufferToS3(
       imageBuffer,
       mimeType,
-      product.id
+      product.id,
     );
 
     // 3. DBのimage_pathを更新
@@ -56,7 +56,7 @@ async function downloadAndUploadImage(product) {
     // 画像のダウンロードやアップロードに失敗しても処理は続行させる
     console.error(
       `Failed to process image for product ${product.id} from ${product.image_url}:`,
-      error.message
+      error.message,
     );
     return null;
   }
@@ -100,7 +100,7 @@ async function handleBarcodeRequest(barcode, res, next) {
     // リダイレクト先の棚IDを取得 (最新更新 or 最初の棚)
     const { rows } = await pool.query(
       `SELECT shelf_id FROM stock WHERE product_id = $1 ORDER BY updated_at DESC, shelf_id ASC LIMIT 1`,
-      [product.id]
+      [product.id],
     );
 
     // createInitialStock が実行されるので、棚は必ず存在するはず
@@ -141,7 +141,7 @@ router.put("/:id(\\d+)", async (req, res, next) => {
   try {
     const id = Number(req.params.id);
     // フロントエンドからS3のURLが imageUrl として渡される
-    const { name, brand, imageUrl } = req.body;
+    const { name, brand, imageUrl, groupId } = req.body;
 
     // 1. 更新対象の商品が存在するか確認
     const existingProduct = await findById(id);
@@ -156,10 +156,10 @@ router.put("/:id(\\d+)", async (req, res, next) => {
 
     // 3. データベースを更新
     const { rows } = await pool.query(
-      `UPDATE products SET name = $1, brand = $2, image_path = $3, updated_at = NOW() 
-       WHERE id = $4 
-       RETURNING id, name, brand, updated_at, COALESCE(image_path, image_url) as image_url`,
-      [name, brand, imagePath, id]
+      `UPDATE products SET name = $1, brand = $2, image_path = $3, group_id = $4, updated_at = NOW()
+       WHERE id = $5
+       RETURNING id, name, brand, group_id, updated_at, COALESCE(image_path, image_url) as image_url`,
+      [name, brand, imagePath, groupId || null, id],
     );
 
     // findByIdでチェック済みのため、この分岐は通常通らない
@@ -261,7 +261,7 @@ router.delete(
     } finally {
       client.release();
     }
-  }
+  },
 );
 
 export default router;

--- a/backend/src/routes/stocks.js
+++ b/backend/src/routes/stocks.js
@@ -85,7 +85,7 @@ router.post(
     } finally {
       client.release();
     }
-  }
+  },
 );
 
 /* ------------------------------------------------------------------ *
@@ -105,7 +105,30 @@ router.get("/", async (_req, res, next) => {
        FROM stock s
        JOIN products p ON s.product_id = p.id
        JOIN shelves sh ON s.shelf_id = sh.id
-       ORDER BY p.name, sh.label`
+       ORDER BY p.name, sh.label`,
+    );
+    res.json(rows);
+  } catch (err) {
+    next(err);
+  }
+});
+
+/* ------------------------------------------------------------------ *
+ * GET /api/stocks/groups
+ *  まとめコード別の在庫数
+ * ------------------------------------------------------------------ */
+router.get("/groups", async (_req, res, next) => {
+  try {
+    const { rows } = await pool.query(
+      `SELECT
+         COALESCE(g.id, 0) AS group_id,
+         COALESCE(g.name, '(未設定)') AS group_name,
+         SUM(s.total_quantity) AS total_quantity
+       FROM stock s
+       JOIN products p ON s.product_id = p.id
+       LEFT JOIN groups g ON p.group_id = g.id
+       GROUP BY g.id, g.name
+       ORDER BY group_name`,
     );
     res.json(rows);
   } catch (err) {
@@ -129,14 +152,14 @@ router.get(
       const { product_id, shelf_id } = req.params;
       const { rows } = await pool.query(
         "SELECT total_quantity FROM stock WHERE product_id=$1 AND shelf_id=$2",
-        [product_id, shelf_id]
+        [product_id, shelf_id],
       );
       if (rows.length === 0) return res.status(404).json({ total_quantity: 0 });
       res.json(rows[0]);
     } catch (err) {
       next(err);
     }
-  }
+  },
 );
 
 /* ------------------------------------------------------------------ *
@@ -163,13 +186,13 @@ router.get(
            FROM stock_history
           WHERE product_id = $1 AND shelf_id = $2
           ORDER BY id DESC LIMIT $3`,
-        [product_id, shelf_id, limit]
+        [product_id, shelf_id, limit],
       );
       res.json(rows);
     } catch (err) {
       next(err);
     }
-  }
+  },
 );
 
 export default router;

--- a/backend/src/routes/stocks.js
+++ b/backend/src/routes/stocks.js
@@ -123,14 +123,43 @@ router.get("/groups", async (_req, res, next) => {
       `SELECT
          COALESCE(g.id, 0) AS group_id,
          COALESCE(g.name, '(未設定)') AS group_name,
+         p.id AS product_id,
+         p.name AS product_name,
          SUM(s.total_quantity) AS total_quantity
        FROM stock s
        JOIN products p ON s.product_id = p.id
        LEFT JOIN groups g ON p.group_id = g.id
-       GROUP BY g.id, g.name
-       ORDER BY group_name`,
+       GROUP BY g.id, g.name, p.id, p.name
+       ORDER BY group_name, product_name`,
     );
-    res.json(rows);
+
+    const map = new Map();
+    for (const row of rows) {
+      const {
+        group_id,
+        group_name,
+        product_id,
+        product_name,
+        total_quantity,
+      } = row;
+      if (!map.has(group_id)) {
+        map.set(group_id, {
+          group_id,
+          group_name,
+          total_quantity: 0,
+          products: [],
+        });
+      }
+      const group = map.get(group_id);
+      group.products.push({
+        product_id,
+        product_name,
+        total_quantity: Number(total_quantity),
+      });
+      group.total_quantity += Number(total_quantity);
+    }
+
+    res.json(Array.from(map.values()));
   } catch (err) {
     next(err);
   }

--- a/frontend/app/products/[id]/page.tsx
+++ b/frontend/app/products/[id]/page.tsx
@@ -7,12 +7,15 @@ import { Button, Input, Label } from "@/lib/form";
 import DeleteProductButton from "@/components/DeleteProductButton";
 import { uploadToS3 } from "@/lib/s3";
 
+type Group = { id: number; name: string };
+
 type Product = {
   id: number;
   name: string;
   brand: string | null;
   imageUrl: string | null;
   notify: boolean;
+  groupId: number | null;
 };
 
 async function getProduct(id: string) {
@@ -23,12 +26,17 @@ async function getProduct(id: string) {
   }
 }
 
+async function listGroups() {
+  return apiGet<Group[]>("/api/groups");
+}
+
 async function updateProductAction(formData: FormData) {
   "use server";
 
   const id = formData.get("id") as string;
   const name = formData.get("name") as string;
   const brand = formData.get("brand") as string;
+  const groupIdStr = formData.get("groupId") as string;
   const notify = formData.get("notify") === "on";
   const imageFile = formData.get("image") as File;
 
@@ -45,9 +53,15 @@ async function updateProductAction(formData: FormData) {
   }
 
   try {
-    const payload: { name: string; brand: string; imageUrl?: string } = {
+    const payload: {
+      name: string;
+      brand: string;
+      imageUrl?: string;
+      groupId: number | null;
+    } = {
       name,
       brand,
+      groupId: groupIdStr ? Number(groupIdStr) : null,
     };
     if (imageUrl) {
       payload.imageUrl = imageUrl;
@@ -86,6 +100,7 @@ export default async function ProductEditPage({
   params: { id: string };
 }) {
   const product = await getProduct(params.id);
+  const groups = await listGroups();
   const deleteProductWithId = deleteProduct.bind(null, params.id);
 
   // DBから取得したオリジナル画像のURLを元に、サムネイルのURLを生成します。
@@ -136,6 +151,23 @@ export default async function ProductEditPage({
         <div>
           <Label htmlFor="brand">ブランド</Label>
           <Input name="brand" id="brand" defaultValue={product.brand ?? ""} />
+        </div>
+
+        <div>
+          <Label htmlFor="groupId">まとめコード</Label>
+          <select
+            name="groupId"
+            id="groupId"
+            defaultValue={product.groupId ?? ""}
+            className="w-full rounded border px-3 py-2 bg-white"
+          >
+            <option value="">(未設定)</option>
+            {groups.map((g) => (
+              <option key={g.id} value={g.id}>
+                {g.name}
+              </option>
+            ))}
+          </select>
         </div>
 
         <label className="inline-flex items-center gap-2">

--- a/frontend/app/stocks/page.tsx
+++ b/frontend/app/stocks/page.tsx
@@ -2,6 +2,7 @@
 "use client";
 import Link from "next/link";
 import useSWR from "swr";
+import { useState } from "react";
 import { getThumbnailUrl } from "@/lib/getThumbnailUrl";
 
 type StockRow = {
@@ -13,10 +14,18 @@ type StockRow = {
   image_url: string | null;
 };
 
+type GroupRow = {
+  group_id: number;
+  group_name: string;
+  total_quantity: number;
+};
+
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
 
 export default function StockListPage() {
-  const { data, error } = useSWR<StockRow[]>("/api/stocks", fetcher);
+  const [view, setView] = useState<"shelf" | "group">("shelf");
+  const endpoint = view === "group" ? "/api/stocks/groups" : "/api/stocks";
+  const { data, error } = useSWR<StockRow[] | GroupRow[]>(endpoint, fetcher);
 
   if (error) return <p className="text-red-600">読み込みエラー</p>;
   if (!data) return <p>読み込み中…</p>;
@@ -25,61 +34,91 @@ export default function StockListPage() {
     <div className="p-4">
       <div className="flex justify-between items-center mb-4">
         <h1 className="text-xl font-bold">在庫一覧</h1>
-        <Link
-          href="/stocks/new"
-          className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 text-sm font-medium"
-        >
-          + 在庫を登録
-        </Link>
+        <div className="flex items-center gap-2">
+          <select
+            value={view}
+            onChange={(e) => setView(e.target.value as "shelf" | "group")}
+            className="border rounded px-2 py-1 text-sm"
+          >
+            <option value="shelf">棚別</option>
+            <option value="group">まとめコード別</option>
+          </select>
+          <Link
+            href="/stocks/new"
+            className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 text-sm font-medium"
+          >
+            + 在庫を登録
+          </Link>
+        </div>
       </div>
-      <table className="w-full text-left border-collapse text-sm">
-        <thead>
-          <tr className="border-b">
-            <th className="py-2 px-2 w-16">画像</th>
-            <th className="py-2 px-2">商品</th>
-            <th className="py-2 px-2">棚</th>
-            <th className="py-2 px-2 text-right">在庫数</th>
-          </tr>
-        </thead>
-        <tbody>
-          {data
-            .filter((row) => row.total_quantity > 0)
-            .map((row) => (
-              <tr
-                key={`${row.product_id}-${row.shelf_id}`}
-                className="border-b last:border-none"
-              >
-                <td className="py-2 px-2">
-                  {row.image_url ? (
-                    <img
-                      src={getThumbnailUrl(row.image_url) || row.image_url}
-                      alt={row.product_name}
-                      className="w-12 h-12 object-cover rounded"
-                      // 画像読み込みエラー時のフォールバック
-                      onError={(e) => (e.currentTarget.style.display = "none")}
-                    />
-                  ) : (
-                    <div className="w-12 h-12 bg-gray-200 rounded flex items-center justify-center text-gray-500">
-                      <span role="img" aria-label="no image">
-                        📦
-                      </span>
-                    </div>
-                  )}
-                </td>
-                <td className="py-2 px-2">
-                  <a
-                    href={`/stocks/${row.shelf_id}/${row.product_id}`}
-                    className="text-blue-600 underline"
-                  >
-                    {row.product_name}
-                  </a>
-                </td>
-                <td className="py-2 px-2">{row.shelf_label}</td>
+      {view === "shelf" ? (
+        <table className="w-full text-left border-collapse text-sm">
+          <thead>
+            <tr className="border-b">
+              <th className="py-2 px-2 w-16">画像</th>
+              <th className="py-2 px-2">商品</th>
+              <th className="py-2 px-2">棚</th>
+              <th className="py-2 px-2 text-right">在庫数</th>
+            </tr>
+          </thead>
+          <tbody>
+            {(data as StockRow[])
+              .filter((row) => row.total_quantity > 0)
+              .map((row) => (
+                <tr
+                  key={`${row.product_id}-${row.shelf_id}`}
+                  className="border-b last:border-none"
+                >
+                  <td className="py-2 px-2">
+                    {row.image_url ? (
+                      <img
+                        src={getThumbnailUrl(row.image_url) || row.image_url}
+                        alt={row.product_name}
+                        className="w-12 h-12 object-cover rounded"
+                        onError={(e) =>
+                          (e.currentTarget.style.display = "none")
+                        }
+                      />
+                    ) : (
+                      <div className="w-12 h-12 bg-gray-200 rounded flex items-center justify-center text-gray-500">
+                        <span role="img" aria-label="no image">
+                          📦
+                        </span>
+                      </div>
+                    )}
+                  </td>
+                  <td className="py-2 px-2">
+                    <a
+                      href={`/stocks/${row.shelf_id}/${row.product_id}`}
+                      className="text-blue-600 underline"
+                    >
+                      {row.product_name}
+                    </a>
+                  </td>
+                  <td className="py-2 px-2">{row.shelf_label}</td>
+                  <td className="py-2 px-2 text-right">{row.total_quantity}</td>
+                </tr>
+              ))}
+          </tbody>
+        </table>
+      ) : (
+        <table className="w-full text-left border-collapse text-sm">
+          <thead>
+            <tr className="border-b">
+              <th className="py-2 px-2">まとめコード</th>
+              <th className="py-2 px-2 text-right">在庫数</th>
+            </tr>
+          </thead>
+          <tbody>
+            {(data as GroupRow[]).map((row) => (
+              <tr key={row.group_id} className="border-b last:border-none">
+                <td className="py-2 px-2">{row.group_name}</td>
                 <td className="py-2 px-2 text-right">{row.total_quantity}</td>
               </tr>
             ))}
-        </tbody>
-      </table>
+          </tbody>
+        </table>
+      )}
     </div>
   );
 }

--- a/frontend/app/stocks/page.tsx
+++ b/frontend/app/stocks/page.tsx
@@ -2,7 +2,7 @@
 "use client";
 import Link from "next/link";
 import useSWR from "swr";
-import { useState } from "react";
+import { useState, Fragment } from "react";
 import { getThumbnailUrl } from "@/lib/getThumbnailUrl";
 
 type StockRow = {
@@ -18,6 +18,11 @@ type GroupRow = {
   group_id: number;
   group_name: string;
   total_quantity: number;
+  products: {
+    product_id: number;
+    product_name: string;
+    total_quantity: number;
+  }[];
 };
 
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
@@ -105,16 +110,27 @@ export default function StockListPage() {
         <table className="w-full text-left border-collapse text-sm">
           <thead>
             <tr className="border-b">
-              <th className="py-2 px-2">まとめコード</th>
+              <th className="py-2 px-2">まとめコード / 商品</th>
               <th className="py-2 px-2 text-right">在庫数</th>
             </tr>
           </thead>
           <tbody>
-            {(data as GroupRow[]).map((row) => (
-              <tr key={row.group_id} className="border-b last:border-none">
-                <td className="py-2 px-2">{row.group_name}</td>
-                <td className="py-2 px-2 text-right">{row.total_quantity}</td>
-              </tr>
+            {(data as GroupRow[]).map((group) => (
+              <Fragment key={group.group_id}>
+                <tr className="border-b bg-gray-50 font-bold">
+                  <td className="py-2 px-2">{group.group_name}</td>
+                  <td className="py-2 px-2 text-right">{group.total_quantity}</td>
+                </tr>
+                {group.products.map((p) => (
+                  <tr
+                    key={`product-${group.group_id}-${p.product_id}`}
+                    className="border-b last:border-none"
+                  >
+                    <td className="py-1 pl-6 pr-2 text-sm">{p.product_name}</td>
+                    <td className="py-1 px-2 text-right">{p.total_quantity}</td>
+                  </tr>
+                ))}
+              </Fragment>
             ))}
           </tbody>
         </table>


### PR DESCRIPTION
## Why
- inventory should be viewable not only by shelf but also by group

## What
- add `/api/stocks/groups` endpoint
- allow updating product group
- toggle inventory list between shelf and group view
- add group selector on product edit screen

## How tested
- `npm --prefix backend install`
- `npm --prefix backend test`


------
https://chatgpt.com/codex/tasks/task_e_6880f4c8c224832e8482ccb72af28b72